### PR TITLE
fix(circuit): use retained launched effect to avoid list jumping on nav pop

### DIFF
--- a/features/bookmarks/src/commonMain/kotlin/dev/avatsav/linkding/bookmarks/ui/list/BookmarksPresenter.kt
+++ b/features/bookmarks/src/commonMain/kotlin/dev/avatsav/linkding/bookmarks/ui/list/BookmarksPresenter.kt
@@ -1,7 +1,6 @@
 package dev.avatsav.linkding.bookmarks.ui.list
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
@@ -37,6 +36,7 @@ import dev.avatsav.linkding.ui.AddBookmarkScreen
 import dev.avatsav.linkding.ui.BookmarksScreen
 import dev.avatsav.linkding.ui.SettingsScreen
 import dev.avatsav.linkding.ui.UrlScreen
+import dev.avatsav.linkding.ui.circuit.RetainedLaunchedEffect
 import dev.avatsav.linkding.ui.circuit.rememberRetainedCachedPagingFlow
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
@@ -75,7 +75,7 @@ class BookmarksPresenter @Inject constructor(
         var category by rememberRetained { mutableStateOf(BookmarkCategory.All) }
         val selectedTags = rememberRetained { mutableStateListOf<Tag>() }
 
-        LaunchedEffect(category, selectedTags.size) {
+        RetainedLaunchedEffect(category, selectedTags.size) {
             retainedObserveBookmarks(
                 ObserveBookmarks.Param(
                     cached = true,
@@ -90,7 +90,7 @@ class BookmarksPresenter @Inject constructor(
             )
         }
 
-        LaunchedEffect(searchQuery) {
+        RetainedLaunchedEffect(searchQuery) {
             retainedObserveSearchResults(
                 ObserveSearchResults.Param(
                     query = searchQuery,

--- a/features/bookmarks/src/commonMain/kotlin/dev/avatsav/linkding/bookmarks/ui/list/BookmarksUiState.kt
+++ b/features/bookmarks/src/commonMain/kotlin/dev/avatsav/linkding/bookmarks/ui/list/BookmarksUiState.kt
@@ -1,6 +1,5 @@
 package dev.avatsav.linkding.bookmarks.ui.list
 
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Immutable
 import androidx.paging.compose.LazyPagingItems
 import com.slack.circuit.runtime.CircuitUiEvent
@@ -10,7 +9,6 @@ import dev.avatsav.linkding.data.model.BookmarkCategory
 import dev.avatsav.linkding.data.model.Tag
 
 @Immutable
-@OptIn(ExperimentalMaterial3Api::class)
 data class BookmarksUiState(
     val bookmarkCategory: BookmarkCategory,
     val bookmarks: LazyPagingItems<Bookmark>,

--- a/ui/circuit/src/commonMain/kotlin/dev/avatsav/linkding/ui/circuit/RetainedLaunchedEffect.kt
+++ b/ui/circuit/src/commonMain/kotlin/dev/avatsav/linkding/ui/circuit/RetainedLaunchedEffect.kt
@@ -1,0 +1,26 @@
+package dev.avatsav.linkding.ui.circuit
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.NonRestartableComposable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import com.slack.circuit.retained.rememberRetained
+import kotlinx.coroutines.CoroutineScope
+
+@Composable
+@NonRestartableComposable
+fun RetainedLaunchedEffect(
+    vararg inputs: Any?,
+    block: suspend CoroutineScope.() -> Unit,
+) {
+    val latestBlock by rememberUpdatedState(block)
+    var launched by rememberRetained(*inputs) { mutableStateOf(false) }
+    LaunchedEffect(*inputs) {
+        if (launched) return@LaunchedEffect
+        launched = true
+        latestBlock()
+    }
+}


### PR DESCRIPTION
Created a `RetainedLaunchedEffect` to void refreshing on navigation-pop and the presenter is recreated. 
Not sure this is the right solution to the list jumping caused due to refresh, but seems to do the job for now. 
