### PR TITLE
fix(circuit): use produceRetainedState for bookmarks and tags flows.

### DIFF
--- a/features/bookmarks/src/commonMain/kotlin/dev/avatsav/linkding/bookmarks/ui/tags/TagsPresenter.kt
+++ b/features/bookmarks/src/commonMain/kotlin/dev/avatsav/linkding/bookmarks/ui/tags/TagsPresenter.kt
@@ -1,8 +1,9 @@
 package dev.avatsav.linkding.bookmarks.ui.tags
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.paging.PagingConfig
+import androidx.paging.cachedIn
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
@@ -13,9 +14,11 @@ import dev.avatsav.linkding.domain.observers.ObserveTags
 import dev.avatsav.linkding.inject.UserScope
 import dev.avatsav.linkding.ui.TagsScreen
 import dev.avatsav.linkding.ui.TagsScreenResult
-import dev.avatsav.linkding.ui.circuit.rememberRetainedCachedPagingFlow
+import dev.avatsav.linkding.ui.circuit.produceRetainedState
+import dev.avatsav.linkding.ui.circuit.rememberRetainedCoroutineScope
 import me.tatarka.inject.annotations.Assisted
 import me.tatarka.inject.annotations.Inject
+import kotlinx.coroutines.flow.emptyFlow
 
 @CircuitInject(TagsScreen::class, UserScope::class)
 class TagsPresenter @Inject constructor(
@@ -26,13 +29,10 @@ class TagsPresenter @Inject constructor(
 
     @Composable
     override fun present(): TagsUiState {
+        val presenterScope = rememberRetainedCoroutineScope()
         val selectedTags = screen.selectedTags.map { it.mapToTag() }
 
-        val tags = observeTags.flow
-            .rememberRetainedCachedPagingFlow()
-            .collectAsLazyPagingItems()
-
-        LaunchedEffect(Unit) {
+        val tagsFlow by produceRetainedState(emptyFlow()) {
             observeTags(
                 ObserveTags.Param(
                     selectedTags,
@@ -42,7 +42,9 @@ class TagsPresenter @Inject constructor(
                     ),
                 ),
             )
+            value = observeTags.flow.cachedIn(presenterScope)
         }
+        val tags = tagsFlow.collectAsLazyPagingItems()
 
         return TagsUiState(
             selectedTags = selectedTags,

--- a/ui/circuit/src/commonMain/kotlin/dev/avatsav/linkding/ui/circuit/ProduceRetainedState.kt
+++ b/ui/circuit/src/commonMain/kotlin/dev/avatsav/linkding/ui/circuit/ProduceRetainedState.kt
@@ -1,0 +1,247 @@
+// Copyright (C) 2022 Slack Technologies, LLC
+// SPDX-License-Identifier: Apache-2.0
+
+package dev.avatsav.linkding.ui.circuit
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.ProduceStateScope
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
+import com.slack.circuit.retained.rememberRetained
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.suspendCancellableCoroutine
+
+/**
+ * This class is a copy with one change from the original.
+ * Using RetainedLaunchedEffect instead of LaunchedEffect
+ * so that the producer isn't called on re-entry to the screen.
+ */
+
+internal class ProduceRetainedStateScopeImpl<T>(
+    state: MutableState<T>,
+    override val coroutineContext: CoroutineContext,
+) : ProduceStateScope<T>,
+    MutableState<T> by state {
+
+    override suspend fun awaitDispose(onDispose: () -> Unit): Nothing {
+        try {
+            suspendCancellableCoroutine<Nothing> {}
+        } finally {
+            onDispose()
+        }
+    }
+}
+
+/**
+ * Return an observable [snapshot][androidx.compose.runtime.snapshots.Snapshot] [State] that
+ * produces values over time without a defined data source.
+ *
+ * [producer] is launched when [produceRetainedState] enters the composition and is cancelled when
+ * [produceRetainedState] leaves the composition. [producer] should use [ProduceStateScope.value] to
+ * set new values on the returned [State].
+ *
+ * The returned [State] conflates values; no change will be observable if [ProduceStateScope.value]
+ * is used to set a value that is [equal][Any.equals] to its old value, and observers may only see
+ * the latest value if several values are set in rapid succession.
+ *
+ * [produceRetainedState] may be used to observe either suspending or non-suspending sources of
+ * external data, for example:
+ * ```
+ * @Composable
+ * fun FavoritesPresenter(favoritesRepository: FavoritesRepository): State {
+ *   val state by produceRetainedState<UiState<List<Person>>>(UiState.Loading, favoritesRepository) {
+ *     favoritesRepository.people
+ *       .map { UiState.Data(it) }
+ *       .collect { value = it }
+ *   }
+ *   return state
+ * }
+ * ```
+ */
+@Composable
+public fun <T> produceRetainedState(
+    initialValue: T,
+    producer: suspend ProduceStateScope<T>.() -> Unit,
+): State<T> {
+    val result = rememberRetained { mutableStateOf(initialValue) }
+    RetainedLaunchedEffect(Unit) {
+        ProduceRetainedStateScopeImpl(
+            result,
+            coroutineContext,
+        ).producer()
+    }
+    return result
+}
+
+/**
+ * Return an observable [snapshot][androidx.compose.runtime.snapshots.Snapshot] [State] that
+ * produces values over time from [key1].
+ *
+ * [producer] is launched when [produceRetainedState] enters the composition and is cancelled when
+ * [produceRetainedState] leaves the composition. If [key1] changes, a running [producer] will be
+ * cancelled and re-launched for the new source. [producer] should use [ProduceStateScope.value] to
+ * set new values on the returned [State].
+ *
+ * The returned [State] conflates values; no change will be observable if [ProduceStateScope.value]
+ * is used to set a value that is [equal][Any.equals] to its old value, and observers may only see
+ * the latest value if several values are set in rapid succession.
+ *
+ * [produceRetainedState] may be used to observe either suspending or non-suspending sources of
+ * external data, for example:
+ * ```
+ * @Composable
+ * fun FavoritesPresenter(favoritesRepository: FavoritesRepository): State {
+ *   val state by produceRetainedState<UiState<List<Person>>>(UiState.Loading, favoritesRepository) {
+ *     favoritesRepository.people
+ *       .map { UiState.Data(it) }
+ *       .collect { value = it }
+ *   }
+ *   return state
+ * }
+ * ```
+ */
+@Composable
+public fun <T> produceRetainedState(
+    initialValue: T,
+    key1: Any?,
+    producer: suspend ProduceStateScope<T>.() -> Unit,
+): State<T> {
+    val result = rememberRetained { mutableStateOf(initialValue) }
+    RetainedLaunchedEffect(key1) {
+        ProduceRetainedStateScopeImpl(
+            result,
+            coroutineContext,
+        ).producer()
+    }
+    return result
+}
+
+/**
+ * Return an observable [snapshot][androidx.compose.runtime.snapshots.Snapshot] [State] that
+ * produces values over time from [key1] and [key2].
+ *
+ * [producer] is launched when [produceRetainedState] enters the composition and is cancelled when
+ * [produceRetainedState] leaves the composition. If [key1] or [key2] change, a running [producer]
+ * will be cancelled and re-launched for the new source. [producer] should use
+ * [ProduceStateScope.value] to set new values on the returned [State].
+ *
+ * The returned [State] conflates values; no change will be observable if [ProduceStateScope.value]
+ * is used to set a value that is [equal][Any.equals] to its old value, and observers may only see
+ * the latest value if several values are set in rapid succession.
+ *
+ * [produceRetainedState] may be used to observe either suspending or non-suspending sources of
+ * external data, for example:
+ * ```
+ * @Composable
+ * fun FavoritesPresenter(favoritesRepository: FavoritesRepository): State {
+ *   val state by produceRetainedState<UiState<List<Person>>>(UiState.Loading, favoritesRepository) {
+ *     favoritesRepository.people
+ *       .map { UiState.Data(it) }
+ *       .collect { value = it }
+ *   }
+ *   return state
+ * }
+ * ```
+ */
+@Composable
+public fun <T> produceRetainedState(
+    initialValue: T,
+    key1: Any?,
+    key2: Any?,
+    producer: suspend ProduceStateScope<T>.() -> Unit,
+): State<T> {
+    val result = rememberRetained { mutableStateOf(initialValue) }
+    RetainedLaunchedEffect(key1, key2) {
+        ProduceRetainedStateScopeImpl(
+            result,
+            coroutineContext,
+        ).producer()
+    }
+    return result
+}
+
+/**
+ * Return an observable [snapshot][androidx.compose.runtime.snapshots.Snapshot] [State] that
+ * produces values over time from [key1], [key2] and [key3].
+ *
+ * [producer] is launched when [produceRetainedState] enters the composition and is cancelled when
+ * [produceRetainedState] leaves the composition. If [key1], [key2] or [key3] change, a running
+ * [producer] will be cancelled and re-launched for the new source.
+ * [producer should use [ProduceStateScope.value] to set new values on the returned [State].
+ *
+ * The returned [State] conflates values; no change will be observable if [ProduceStateScope.value]
+ * is used to set a value that is [equal][Any.equals] to its old value, and observers may only see
+ * the latest value if several values are set in rapid succession.
+ *
+ * [produceRetainedState] may be used to observe either suspending or non-suspending sources of
+ * external data, for example:
+ * ```
+ * @Composable
+ * fun FavoritesPresenter(favoritesRepository: FavoritesRepository): State {
+ *   val state by produceRetainedState<UiState<List<Person>>>(UiState.Loading, favoritesRepository) {
+ *     favoritesRepository.people
+ *       .map { UiState.Data(it) }
+ *       .collect { value = it }
+ *   }
+ *   return state
+ * }
+ * ```
+ */
+@Composable
+public fun <T> produceRetainedState(
+    initialValue: T,
+    key1: Any?,
+    key2: Any?,
+    key3: Any?,
+    producer: suspend ProduceStateScope<T>.() -> Unit,
+): State<T> {
+    val result = rememberRetained { mutableStateOf(initialValue) }
+    RetainedLaunchedEffect(key1, key2, key3) {
+        ProduceRetainedStateScopeImpl(result, coroutineContext).producer()
+    }
+    return result
+}
+
+/**
+ * Return an observable [snapshot][androidx.compose.runtime.snapshots.Snapshot] [State] that
+ * produces values over time from [keys].
+ *
+ * [producer] is launched when [produceRetainedState] enters the composition and is cancelled when
+ * [produceRetainedState] leaves the composition. If [keys] change, a running [producer] will be
+ * cancelled and re-launched for the new source. [producer] should use [ProduceStateScope.value] to
+ * set new values on the returned [State].
+ *
+ * The returned [State] conflates values; no change will be observable if [ProduceStateScope.value]
+ * is used to set a value that is [equal][Any.equals] to its old value, and observers may only see
+ * the latest value if several values are set in rapid succession.
+ *
+ * [produceRetainedState] may be used to observe either suspending or non-suspending sources of
+ * external data, for example:
+ * ```
+ * @Composable
+ * fun FavoritesPresenter(favoritesRepository: FavoritesRepository): State {
+ *   val state by produceRetainedState<UiState<List<Person>>>(UiState.Loading, favoritesRepository) {
+ *     favoritesRepository.people
+ *       .map { UiState.Data(it) }
+ *       .collect { value = it }
+ *   }
+ *   return state
+ * }
+ * ```
+ */
+@Composable
+public fun <T> produceRetainedState(
+    initialValue: T,
+    vararg keys: Any?,
+    producer: suspend ProduceStateScope<T>.() -> Unit,
+): State<T> {
+    val result = rememberRetained { mutableStateOf(initialValue) }
+    RetainedLaunchedEffect(keys) {
+        ProduceRetainedStateScopeImpl(
+            result,
+            coroutineContext,
+        ).producer()
+    }
+    return result
+}

--- a/ui/circuit/src/commonMain/kotlin/dev/avatsav/linkding/ui/circuit/RetainedLaunchedEffect.kt
+++ b/ui/circuit/src/commonMain/kotlin/dev/avatsav/linkding/ui/circuit/RetainedLaunchedEffect.kt
@@ -12,13 +12,13 @@ import kotlinx.coroutines.CoroutineScope
 
 @Composable
 @NonRestartableComposable
-fun RetainedLaunchedEffect(
-    vararg inputs: Any?,
+internal fun RetainedLaunchedEffect(
+    vararg keys: Any?,
     block: suspend CoroutineScope.() -> Unit,
 ) {
     val latestBlock by rememberUpdatedState(block)
-    var launched by rememberRetained(*inputs) { mutableStateOf(false) }
-    LaunchedEffect(*inputs) {
+    var launched by rememberRetained(*keys) { mutableStateOf(false) }
+    LaunchedEffect(*keys) {
         if (launched) return@LaunchedEffect
         launched = true
         latestBlock()


### PR DESCRIPTION
Use `produceRetainedState` to produce the flows instead of LaunchedEffect.

### `produceRetainedState`

The `produceRetainedState` differs from the original implementation in Circuit: https://github.com/slackhq/circuit/blob/main/circuit-retained/src/commonMain/kotlin/com/slack/circuit/retained/ProduceRetainedState.kt
It uses the `RetainedLanchedEffect` instead of `LaunchedEffect`. This will the producer only once(and on key change) and not on every re-entry to the screen from the backstack. 

TODO: Clarify with Circuit if what the intended behavior of the `produceRetainedState` and if it's a deliberate decision to call the producer.  